### PR TITLE
Bump GO version to 1.11.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ IF (BUILD_ENTERPRISE)
     GOPATH "${PROJECT_SOURCE_DIR}/../../../.." "${GODEPSDIR}"
     LDFLAGS "${_ldflags}"
     INSTALL_PATH bin OUTPUT cbsummary
-    GOVERSION 1.11.4)
+    GOVERSION 1.11.6)
 
 #  ADD_SUBDIRECTORY(docs)
 


### PR DESCRIPTION
1.11.4 was only used by cbsummary and by using 1.11.6 we use
the same version of 1.11 as the rest of the components using
a version on the 1.11 line